### PR TITLE
DeprecationWarning: on_setup_env

### DIFF
--- a/lektor_google_analytics.py
+++ b/lektor_google_analytics.py
@@ -19,7 +19,7 @@ class GoogleAnalyticsPlugin(Plugin):
     name = u'Google Analytics'
     description = u'adds support for Google Analytics to Lektor CMS'
 
-    def on_setup_env(self):
+    def on_setup_env(self, **extra):
         ga_property = self.get_config().get('GOOGLE_ANALYTICS_PROPERTY', 'auto')
         google_analytics_id = self.get_config().get('GOOGLE_ANALYTICS_ID')
 


### PR DESCRIPTION
Executing `lektor build`

```
lektor/pluginsystem.py:171: DeprecationWarning: The plugin "google-analytics" function "on_setup_env" 
does not accept extra_flags.
It should be updated to accept `**extra` so that it will not break if new parameters are passed to it
by newer versions of Lektor.
```

[Setup-env Documentation](https://www.getlektor.com/docs/api/plugins/events/setup-env/)